### PR TITLE
FancyRoleCategories correction due to new discord css class naming

### DIFF
--- a/FancyRoleCategories.css
+++ b/FancyRoleCategories.css
@@ -7,20 +7,20 @@
     --catagoryTitleUppercase: uppercase; /* change to 'none' to remove Uppercasing of catagory titles */
 }
 
-.members-3WRCEx .container-1oeRFJ, .membersGroup-2eiWxl {
+.members-2y1nVj .container-1oeRFJ, .membersGroup-2YoqY- {
     background-color: var(--catagory-background);
 }
 
-.membersGroup-2eiWxl{ /* Role Catagory */
+.membersGroup-2YoqY-{ /* Role Catagory */
 	text-transform: var(--catagoryTitleUppercase); /* make catagory title uppercase */
 	text-align: var(--catagoryAlignment); /* center title */
 	border-radius: var(--catagory-radius) var(--catagory-radius) 0px 0px; /* add border */
 	margin-top: var(--catagory-spacing); /* add role gap */
     margin-left: 8px; padding-top: 12px; /* clean up formatting */
 }
-.members-3WRCEx .container-1oeRFJ:has(+ .membersGroup-2eiWxl), .members-3WRCEx .container-1oeRFJ:last-child{
+.members-2y1nVj .container-1oeRFJ:has(+ .membersGroup-2YoqY-), .members-2y1nVj .container-1oeRFJ:last-child{
 	border-radius: 0 0 var(--catagory-radius) var(--catagory-radius) !important; /* add border */
 }
-.members-3WRCEx .container-1oeRFJ:has(+ .container-1oeRFJ){
+.members-2y1nVj .container-1oeRFJ:has(+ .container-1oeRFJ){
 	border-radius: 0
 }


### PR DESCRIPTION
This is the fix for Issue #1 
After the last update of Discord in the Beta Channel, the snippet stopped working. This code change after the snippet FancyRoleCategories functional again